### PR TITLE
Update version of Elixir and Erlang in elixir_buildpack.config for #7

### DIFF
--- a/elixir_buildpack.config
+++ b/elixir_buildpack.config
@@ -1,8 +1,8 @@
 # Latest version of Erlang/OTP see: https://git.io/Je5k6
-erlang_version=22.2
+erlang_version=23.0
 
 # Latest Elixir Version see: https://github.com/elixir-lang/elixir/releases
-elixir_version=1.9.4
+elixir_version=1.10
 
 # Always rebuild from scratch on every deploy?
 always_rebuild=false


### PR DESCRIPTION
Heroku build fails because of Elixir version mismatch #7 